### PR TITLE
Improve GitHub workflow security with user authorization

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Filter by PR author - only allow bborbe and trusted users
+    if: |
+      github.event.pull_request.user.login == 'bborbe' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'OWNER'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,17 +11,72 @@ on:
     types: [submitted]
 
 jobs:
+  # Check if user is authorized to trigger Claude
+  check-auth:
+    runs-on: ubuntu-latest
+    outputs:
+      authorized: ${{ steps.auth.outputs.authorized }}
+      has-trigger: ${{ steps.trigger.outputs.has-trigger }}
+    steps:
+      - name: Check authorization
+        id: auth
+        run: |
+          if [[ "${{ github.actor }}" == "bborbe" ]]; then
+            echo "authorized=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          case "${{ github.event_name }}" in
+            "pull_request_review_comment"|"pull_request_review")
+              association="${{ github.event.pull_request.author_association }}"
+              ;;
+            "issue_comment"|"issues")
+              association="${{ github.event.issue.author_association }}"
+              ;;
+            *)
+              association=""
+              ;;
+          esac
+          
+          if [[ "$association" == "COLLABORATOR" || "$association" == "MEMBER" || "$association" == "OWNER" ]]; then
+            echo "authorized=true" >> $GITHUB_OUTPUT
+          else
+            echo "authorized=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Check trigger phrase
+        id: trigger
+        run: |
+          case "${{ github.event_name }}" in
+            "issue_comment"|"pull_request_review_comment")
+              if [[ "${{ contains(github.event.comment.body, '@claude') }}" == "true" ]]; then
+                echo "has-trigger=true" >> $GITHUB_OUTPUT
+              else
+                echo "has-trigger=false" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            "pull_request_review")
+              if [[ "${{ contains(github.event.review.body, '@claude') }}" == "true" ]]; then
+                echo "has-trigger=true" >> $GITHUB_OUTPUT
+              else
+                echo "has-trigger=false" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            "issues")
+              if [[ "${{ contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude') }}" == "true" ]]; then
+                echo "has-trigger=true" >> $GITHUB_OUTPUT
+              else
+                echo "has-trigger=false" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            *)
+              echo "has-trigger=false" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
   claude:
-    if: |
-      (github.actor == 'bborbe' || 
-       (github.event_name == 'pull_request_review_comment' && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER')) ||
-       (github.event_name == 'pull_request_review' && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER')) ||
-       (github.event_name == 'issue_comment' && (github.event.issue.author_association == 'COLLABORATOR' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER')) ||
-       (github.event_name == 'issues' && (github.event.issue.author_association == 'COLLABORATOR' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER'))) &&
-      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
+    needs: check-auth
+    if: needs.check-auth.outputs.authorized == 'true' && needs.check-auth.outputs.has-trigger == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,9 +14,10 @@ jobs:
   claude:
     if: |
       (github.actor == 'bborbe' || 
-       github.event.pull_request.author_association == 'COLLABORATOR' || 
-       github.event.pull_request.author_association == 'MEMBER' || 
-       github.event.pull_request.author_association == 'OWNER') &&
+       (github.event_name == 'pull_request_review_comment' && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER')) ||
+       (github.event_name == 'pull_request_review' && (github.event.pull_request.author_association == 'COLLABORATOR' || github.event.pull_request.author_association == 'MEMBER' || github.event.pull_request.author_association == 'OWNER')) ||
+       (github.event_name == 'issue_comment' && (github.event.issue.author_association == 'COLLABORATOR' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER')) ||
+       (github.event_name == 'issues' && (github.event.issue.author_association == 'COLLABORATOR' || github.event.issue.author_association == 'MEMBER' || github.event.issue.author_association == 'OWNER'))) &&
       ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,14 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.actor == 'bborbe' || 
+       github.event.pull_request.author_association == 'COLLABORATOR' || 
+       github.event.pull_request.author_association == 'MEMBER' || 
+       github.event.pull_request.author_association == 'OWNER') &&
+      ((github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))))
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary
- Added user authorization checks to Claude Code Review and Claude PR Assistant workflows
- Restricts access to trusted users (bborbe and users with COLLABORATOR, MEMBER, or OWNER associations)
- Prevents unauthorized users from triggering Claude actions on pull requests and issues

## Test plan
- Verify workflows only trigger for authorized users
- Test that unauthorized users cannot trigger Claude actions
- Confirm existing functionality works for authorized users